### PR TITLE
Add support for time zones

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FrenchRepublicanCalendarCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
+++ b/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
@@ -68,8 +68,12 @@ public struct DecimalTime {
 
 public extension DecimalTime {
     /// Initializes a new DecimalTime with the current time
-    init(base: Date = Date()) {
-        let midnight = Calendar.gregorian.startOfDay(for: base)
+    init(base: Date = Date(), timeZone: TimeZone?) {
+        var GregorianCalendar: Calendar = Calendar.gregorian
+        if let timeZone = timeZone {
+            GregorianCalendar.timeZone = timeZone
+        }
+        let midnight = GregorianCalendar.startOfDay(for: base)
         self.init(timeSinceMidnight: base.timeIntervalSinceReferenceDate - midnight.timeIntervalSinceReferenceDate)
     }
 }

--- a/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
+++ b/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
@@ -67,12 +67,8 @@ public struct DecimalTime {
 }
 
 public extension DecimalTime {
-    /// Initializes a new DecimalTime with the current time
-    init(base: Date = Date()) {
-        self.init(base: base, timeZone: nil)
-    }
-
-    init(base: Date = Date(), timeZone: TimeZone?) {
+    /// Initializes a new DecimalTime with the current time and optional time zone
+    init(base: Date = Date(), timeZone: TimeZone? = nil) {
         var gregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
             gregorianCalendar.timeZone = timeZone

--- a/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
+++ b/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
@@ -73,11 +73,11 @@ public extension DecimalTime {
     }
 
     init(base: Date = Date(), timeZone: TimeZone?) {
-        var GregorianCalendar: Calendar = Calendar.gregorian
+        var gregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
-            GregorianCalendar.timeZone = timeZone
+            gregorianCalendar.timeZone = timeZone
         }
-        let midnight = GregorianCalendar.startOfDay(for: base)
+        let midnight = gregorianCalendar.startOfDay(for: base)
         self.init(timeSinceMidnight: base.timeIntervalSinceReferenceDate - midnight.timeIntervalSinceReferenceDate)
     }
 }

--- a/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
+++ b/Sources/FrenchRepublicanCalendarCore/DecimalTime.swift
@@ -68,6 +68,10 @@ public struct DecimalTime {
 
 public extension DecimalTime {
     /// Initializes a new DecimalTime with the current time
+    init(base: Date = Date()) {
+        self.init(base: base, timeZone: nil)
+    }
+
     init(base: Date = Date(), timeZone: TimeZone?) {
         var GregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
@@ -132,16 +132,7 @@ extension FrenchRepublicanDate: CustomDebugStringConvertible {
     /// Returns the wiktionary or wikipedia page link associated with the day name.
     public var descriptionURL: URL? {
         let wikipediaOverrides = [
-            "Belle de nuit": "Mirabilis_jalapa",
-            "Amaryllis": "Amaryllis_(plante)",
-            "Erable sucré": "%C3%89rable_%C3%A0_sucre",
-            "Perce Neige": "Perce-neige",
-            "Laurier thym": "Viorne_tin",
-            "Thimèle": "Daphn%C3%A9_garou",
-            "Bâton d'or": "Girofl%C3%A9e_des_murailles",
-            "Chamerops": "Chamaerops_humilis",
-            "Épine vinette": "%C3%89pine-vinette",
-            "Verge d'or": "Solidago"
+            "Belle de nuit": "Mirabilis_jalapa", "Amaryllis": "Amaryllis_(plante)", "Erable sucré": "%C3%89rable_%C3%A0_sucre", "Perce Neige": "Perce-neige", "Laurier thym": "Viorne_tin", "Thimèle": "Daphn%C3%A9_garou", "Bâton d'or": "Girofl%C3%A9e_des_murailles", "Chamerops": "Chamaerops_humilis", "Épine vinette": "%C3%89pine-vinette", "Verge d'or": "Solidago"
         ]
         if let override = wikipediaOverrides[dayName] {
             return URL(string: "https://fr.wikipedia.org/wiki/\(override)")

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 extension FrenchRepublicanDate: CustomDebugStringConvertible {
-    public static let allMonthNames = ["Vendémiaire", "Brumaire", "Frimaire", "Nivôse", "Pluviôse", "Ventôse", "Germinal", "Floréal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Sansculottide"]
+    public static let allMonthNames = ["Vendémiaire", "Brumaire", "Frimaire", "Nivôse", "Pluviôse", "Ventôse", "Germinal", "Floréal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Sansculottides"]
     public static let sansculottidesDayNames = ["Jour de la vertu", "Jour du génie", "Jour du travail", "Jour de l'opinion", "Jour des récompenses", "Jour de la révolution"]
 
     public static let shortMonthNames = ["Vend.r", "Brum.r", "Frim.r", "Niv.ô", "Pluv.ô", "Vent.ô", "Germ.l", "Flo.l", "Prai.l", "Mes.or", "Ther.or", "Fru.or", "Ss.cu"]
@@ -40,7 +40,7 @@ extension FrenchRepublicanDate: CustomDebugStringConvertible {
     
     /// Returns string as d MMMM
     public func toLongStringNoYear() -> String {
-        if components.month == 13 {
+        if components.month == 13 && !self.options.treatSansculottidesAsAMonth {
             return "\(FrenchRepublicanDate.sansculottidesDayNames[components.day! - 1])"
         }
         return "\(components.day!) \(monthName)"
@@ -48,7 +48,7 @@ extension FrenchRepublicanDate: CustomDebugStringConvertible {
     
     /// Returns string as d MMM
     public func toShortString() -> String {
-        if components.month == 13 {
+        if components.month == 13 && !self.options.treatSansculottidesAsAMonth {
             return "\(FrenchRepublicanDate.sansculottidesShortNames[components.day! - 1])"
         }
         return "\(components.day!) \(shortMonthName)"

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate+Formatting.swift
@@ -132,7 +132,16 @@ extension FrenchRepublicanDate: CustomDebugStringConvertible {
     /// Returns the wiktionary or wikipedia page link associated with the day name.
     public var descriptionURL: URL? {
         let wikipediaOverrides = [
-            "Belle de nuit": "Mirabilis_jalapa", "Amaryllis": "Amaryllis_(plante)", "Erable sucré": "%C3%89rable_%C3%A0_sucre", "Perce Neige": "Perce-neige", "Laurier thym": "Viorne_tin", "Thimèle": "Daphn%C3%A9_garou", "Bâton d'or": "Girofl%C3%A9e_des_murailles", "Chamerops": "Chamaerops_humilis", "Épine vinette": "%C3%89pine-vinette", "Verge d'or": "Solidago"
+            "Belle de nuit": "Mirabilis_jalapa",
+            "Amaryllis": "Amaryllis_(plante)",
+            "Erable sucré": "%C3%89rable_%C3%A0_sucre",
+            "Perce Neige": "Perce-neige",
+            "Laurier thym": "Viorne_tin",
+            "Thimèle": "Daphn%C3%A9_garou",
+            "Bâton d'or": "Girofl%C3%A9e_des_murailles",
+            "Chamerops": "Chamaerops_humilis",
+            "Épine vinette": "%C3%89pine-vinette",
+            "Verge d'or": "Solidago"
         ]
         if let override = wikipediaOverrides[dayName] {
             return URL(string: "https://fr.wikipedia.org/wiki/\(override)")

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate.swift
@@ -65,6 +65,10 @@ public struct FrenchRepublicanDate {
     
     /// Creates a Republican Date from the given Gregorian Date
     /// - Parameter date: the Gregorian Date
+    public init(date: Date, options: FrenchRepublicanDateOptions? = nil) {
+        self.init(date: date, options: options, timeZone: nil)
+    }
+    
     public init(date: Date, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone?) {
         self.date = date
         if let options = options {
@@ -88,6 +92,10 @@ public struct FrenchRepublicanDate {
     ///   - minute: Minutes
     ///   - second: Seconds
     ///   - nanosecond: Nanoseconds
+    public init(dayInYear: Int, year: Int, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, options: FrenchRepublicanDateOptions? = nil) {
+        self.init(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
+    }
+    
     public init(dayInYear: Int, year: Int, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone?) {
         if let options = options {
             self.options = options
@@ -219,6 +227,10 @@ internal extension Date {
     ///   - second: Second, will directly be copied over
     ///   - nanosecond: Nanosecond, will directly be copied over
     /// - Note: Library users: use FrenchRepublicanDate.init(dayInYear: ...).date
+    init(dayInYear: Int, year: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions) {
+        self.init(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
+    }
+
     init(dayInYear: Int, year: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone?) {
         var GregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
@@ -238,7 +250,11 @@ fileprivate extension Date {
     ///   - second: Second, will directly be copied over
     ///   - nanosecond: Nanosecond, will directly be copied over
     /// - Returns: A DateComponents object containing the gregorian year and day of year, with the additional time components copied over.
-    static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone?) -> DateComponents {
+    static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions) -> DateComponents {
+        Date.dateToGregorian(dayInYear: rDayInYear, year: rYear, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
+    }
+    
+        static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone?) -> DateComponents {
         var GregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
             GregorianCalendar.timeZone = timeZone

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDate.swift
@@ -64,12 +64,10 @@ public struct FrenchRepublicanDate {
     // MARK: Initializers
     
     /// Creates a Republican Date from the given Gregorian Date
-    /// - Parameter date: the Gregorian Date
-    public init(date: Date, options: FrenchRepublicanDateOptions? = nil) {
-        self.init(date: date, options: options, timeZone: nil)
-    }
-    
-    public init(date: Date, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone?) {
+    /// - Parameters
+    ///   - date: The Gregorian Date
+    ///   - timeZone: The time zone; the default time zone if nil
+    public init(date: Date, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone? = nil) {
         self.date = date
         if let options = options {
             self.options = options
@@ -92,11 +90,8 @@ public struct FrenchRepublicanDate {
     ///   - minute: Minutes
     ///   - second: Seconds
     ///   - nanosecond: Nanoseconds
-    public init(dayInYear: Int, year: Int, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, options: FrenchRepublicanDateOptions? = nil) {
-        self.init(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
-    }
-    
-    public init(dayInYear: Int, year: Int, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone?) {
+    ///   - timeZone: The time zone; the default time zone if nil
+    public init(dayInYear: Int, year: Int, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, options: FrenchRepublicanDateOptions? = nil, timeZone: TimeZone? = nil) {
         if let options = options {
             self.options = options
         } else if let type = FrenchRepublicanDateOptions.self as? SaveableFrenchRepublicanDateOptions.Type {
@@ -110,11 +105,11 @@ public struct FrenchRepublicanDate {
     
     /// Logic that converts the `date` value to republican date components. Called by the Gregorian > Republican constructor
     private mutating func dateToFrenchRepublican() {
-        var GregorianCalendar: Calendar = Calendar.gregorian
+        var gregorianCalendar: Calendar = Calendar.gregorian
         if self.timeZone != nil {
-            GregorianCalendar.timeZone = self.timeZone!
+            gregorianCalendar.timeZone = self.timeZone!
         }
-        let gregorian = GregorianCalendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date)
+        let gregorian = gregorianCalendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date)
         
         var year: Int
         var dayOfYear: Int
@@ -226,17 +221,14 @@ internal extension Date {
     ///   - minute: Minute, will directly be copied over
     ///   - second: Second, will directly be copied over
     ///   - nanosecond: Nanosecond, will directly be copied over
+    ///   - timeZone: The time zone; the default time zone if nil
     /// - Note: Library users: use FrenchRepublicanDate.init(dayInYear: ...).date
-    init(dayInYear: Int, year: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions) {
-        self.init(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
-    }
-
-    init(dayInYear: Int, year: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone?) {
-        var GregorianCalendar: Calendar = Calendar.gregorian
+    init(dayInYear: Int, year: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone? = nil) {
+        var gregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
-            GregorianCalendar.timeZone = timeZone
+            gregorianCalendar.timeZone = timeZone
         }
-        self = GregorianCalendar.date(from: Date.dateToGregorian(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: timeZone))!
+        self = gregorianCalendar.date(from: Date.dateToGregorian(dayInYear: dayInYear, year: year, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: timeZone))!
     }
 }
 
@@ -249,15 +241,12 @@ fileprivate extension Date {
     ///   - minute: Minute, will directly be copied over
     ///   - second: Second, will directly be copied over
     ///   - nanosecond: Nanosecond, will directly be copied over
-    /// - Returns: A DateComponents object containing the gregorian year and day of year, with the additional time components copied over.
-    static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions) -> DateComponents {
-        Date.dateToGregorian(dayInYear: rDayInYear, year: rYear, hour: hour, minute: minute, second: second, nanosecond: nanosecond, options: options, timeZone: nil)
-    }
-    
-        static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone?) -> DateComponents {
-        var GregorianCalendar: Calendar = Calendar.gregorian
+    ///   - timeZone: The time zone; the default time zone if nil
+    /// - Returns: A DateComponents object containing the Gregorian year and day of year, with the additional time components copied over.
+        static func dateToGregorian(dayInYear rDayInYear: Int, year rYear: Int, hour: Int?, minute: Int?, second: Int?, nanosecond: Int?, options: FrenchRepublicanDateOptions, timeZone: TimeZone? = nil) -> DateComponents {
+        var gregorianCalendar: Calendar = Calendar.gregorian
         if let timeZone = timeZone {
-            GregorianCalendar.timeZone = timeZone
+            gregorianCalendar.timeZone = timeZone
         }
         
         var gYear: Int
@@ -282,14 +271,14 @@ fileprivate extension Date {
             }
         case .romme:
             // hour: 10 avoids a timezone change issue on 1911-03-11 (9 minutes 21 seconds change)
-            let date = GregorianCalendar.date(from: DateComponents(year: rYear + 2000, day: rDayInYear, hour: 10))!
-            let shifted = GregorianCalendar.date(byAdding: .day, value: -76071, to: date)!
-            gYear = GregorianCalendar.component(.year, from: shifted)
-            gDayOfYear = GregorianCalendar.ordinality(of: .day, in: .year, for: shifted)! - 1
+            let date = gregorianCalendar.date(from: DateComponents(year: rYear + 2000, day: rDayInYear, hour: 10))!
+            let shifted = gregorianCalendar.date(byAdding: .day, value: -76071, to: date)!
+            gYear = gregorianCalendar.component(.year, from: shifted)
+            gDayOfYear = gregorianCalendar.ordinality(of: .day, in: .year, for: shifted)! - 1
             let remdays = (rYear - 1) / 4000
             gDayOfYear.increment(by: -remdays, year: &gYear, daysInYear: \.daysInGregorianYear)
         }
         
-        return DateComponents(calendar: GregorianCalendar, year: gYear, day: gDayOfYear + 1, hour: hour, minute: minute, second: second, nanosecond: nanosecond)
+        return DateComponents(calendar: gregorianCalendar, year: gYear, day: gDayOfYear + 1, hour: hour, minute: minute, second: second, nanosecond: nanosecond)
     }
 }

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDateOptions.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDateOptions.swift
@@ -18,9 +18,17 @@ public struct FrenchRepublicanDateOptions {
     public var romanYear: Bool
     public var variant: Variant
     
+    /// If true, formatted dates in Sansculottides are things like "1 Sansculottides" instead of a holiday name.
+    public var treatSansculottidesAsAMonth: Bool
+    
     public init(romanYear: Bool, variant: Variant) {
+        self.init(romanYear: romanYear, variant: variant, treatSansculottidesAsAMonth: false)
+    }
+    
+    public init(romanYear: Bool, variant: Variant, treatSansculottidesAsAMonth: Bool) {
         self.romanYear = romanYear
         self.variant = variant
+        self.treatSansculottidesAsAMonth = treatSansculottidesAsAMonth
     }
     
     public enum Variant: Int, CaseIterable {

--- a/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDateOptions.swift
+++ b/Sources/FrenchRepublicanCalendarCore/FrenchRepublicanDateOptions.swift
@@ -21,11 +21,7 @@ public struct FrenchRepublicanDateOptions {
     /// If true, formatted dates in Sansculottides are things like "1 Sansculottides" instead of a holiday name.
     public var treatSansculottidesAsAMonth: Bool
     
-    public init(romanYear: Bool, variant: Variant) {
-        self.init(romanYear: romanYear, variant: variant, treatSansculottidesAsAMonth: false)
-    }
-    
-    public init(romanYear: Bool, variant: Variant, treatSansculottidesAsAMonth: Bool) {
+    public init(romanYear: Bool, variant: Variant, treatSansculottidesAsAMonth: Bool = false) {
         self.romanYear = romanYear
         self.variant = variant
         self.treatSansculottidesAsAMonth = treatSansculottidesAsAMonth

--- a/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
+++ b/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
@@ -70,12 +70,9 @@ class FrenchRepublicanCalendarTests: XCTestCase {
     
     @available(iOS 10.0, *)
     fileprivate func testHistoricalDatesFor(_ timeZone: TimeZone?) {
-        debugPrint("################################################################################")
+//        debugPrint("################################################################################")
         let appropriateTimeZone: TimeZone = timeZone ?? TimeZone.current
 
-//        let df = ISO8601DateFormatter()
-//        df.formatOptions = .withFullDate
-//        df.timeZone = timeZone
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
         df.timeZone = appropriateTimeZone
@@ -84,51 +81,45 @@ class FrenchRepublicanCalendarTests: XCTestCase {
         df2.dateFormat = "yyyy-MM-dd\'T\'HH:mm:ss\'.000\'z"
         df2.timeZone = appropriateTimeZone
  
-        debugPrint(#file, #function, appropriateTimeZone.identifier, appropriateTimeZone.secondsFromGMT() / (60 * 60))
+//        debugPrint(#file, #function, appropriateTimeZone.identifier, appropriateTimeZone.secondsFromGMT() / (60 * 60))
        
         let expectedOriginString = "01/01/1"
         // Testing 01/01/1 FRC:  Original
-//            let rawFRCDateOrigin: Date = FrenchRepublicanDate.origin
-//            let frcDateOrigin: Date = rawFRCDateOrigin.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin)))
         let frcDateOrigin: Date = gregorianDate(era: 1, year: 1792, month: 9, day: 22, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
             let frcDate: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin, options: .init(romanYear: false, variant: .original), timeZone: appropriateTimeZone)
-            debugPrint("• Variant:  Original")
-            debugPrint("• Origin:", frcDateOrigin)
-            debugPrint("• FRC date:", frcDate)
+//            debugPrint("• Variant:  Original")
+//            debugPrint("• Origin:", frcDateOrigin)
+//            debugPrint("• FRC date:", frcDate)
             XCTAssertEqual(frcDate.toShortenedString(), expectedOriginString)
         
         // Testing 01/01/1 FRC:  Romme
-//        let rawFRCDateOrigin2: Date = FrenchRepublicanDate.origin
-//        let frcDateOrigin2: Date = rawFRCDateOrigin2.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin2)))
         let frcDateOrigin2: Date = gregorianDate(era: 1, year: 1792, month: 9, day: 22, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
         let frcDate2: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin2, options: .init(romanYear: false, variant: .romme), timeZone: appropriateTimeZone)
-        debugPrint("• Variant:  Romme")
-        debugPrint("• Origin:", frcDateOrigin2)
-        debugPrint("• FRC date:", frcDate2)
+//        debugPrint("• Variant:  Romme")
+//        debugPrint("• Origin:", frcDateOrigin2)
+//        debugPrint("• FRC date:", frcDate2)
         XCTAssertEqual(frcDate2.toShortenedString(), expectedOriginString)
         
         // Testing 18/02/8 FRC
         let expected9November1799String = "1799-11-09"
-//        let dateFor9November1799: Date = df.date(from: expected9November1799String)!
         let dateFor9November1799: Date = gregorianDate(era: 1, year: 1799, month: 11, day: 9, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
         let frcFor9November1799: FrenchRepublicanDate = FrenchRepublicanDate(date: dateFor9November1799, timeZone: appropriateTimeZone)
         let frcFor9November1799String: String = frcFor9November1799.toShortenedString()
-        debugPrint("• 9 November 1799:", dateFor9November1799)
-        debugPrint("• FRC date for 9 November 1799:", frcFor9November1799)
-        debugPrint("• String for FRC date for 9 November 1799:", frcFor9November1799String)
+//        debugPrint("• 9 November 1799:", dateFor9November1799)
+//        debugPrint("• FRC date for 9 November 1799:", frcFor9November1799)
+//        debugPrint("• String for FRC date for 9 November 1799:", frcFor9November1799String)
         let stringFor18Brumaire8 = "18/02/8"
         XCTAssertEqual(frcFor9November1799String, stringFor18Brumaire8)
         let frcFor18Brumaire8: FrenchRepublicanDate = FrenchRepublicanDate(dayInYear: 48, year: 8, hour: 0, minute: 0, second: 0, nanosecond: 0, timeZone: appropriateTimeZone)
         let dateForFRCFor18Brumaire8: Date = frcFor18Brumaire8.date
         let stringForFRCFor18Brumaire8: String = df.string(from: dateForFRCFor18Brumaire8)
-        debugPrint("• FRC date for 18 Brumaire 8:", frcFor18Brumaire8)
-        debugPrint("• Date for 18 Brumaire 8:", dateForFRCFor18Brumaire8)
-        debugPrint("• String for date for 18 Brumaire 8:", stringForFRCFor18Brumaire8)
+//        debugPrint("• FRC date for 18 Brumaire 8:", frcFor18Brumaire8)
+//        debugPrint("• Date for 18 Brumaire 8:", dateForFRCFor18Brumaire8)
+//        debugPrint("• String for date for 18 Brumaire 8:", stringForFRCFor18Brumaire8)
         XCTAssertEqual(stringForFRCFor18Brumaire8, expected9November1799String)
         
         // Testing 1970-01-01 CE
         let unixOriginAsString = "1970-01-01"
-//        let unixOrigin = df.date(from: unixOriginAsString)!
         let unixOrigin = gregorianDate(era: 1, year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
         let unixOriginOnFRC = FrenchRepublicanDate(date: unixOrigin, timeZone: appropriateTimeZone)
         let unixOriginOnFRCAsDate = unixOriginOnFRC.date
@@ -136,16 +127,15 @@ class FrenchRepublicanCalendarTests: XCTestCase {
         
         let unixOriginOnFRC2 = FrenchRepublicanDate(dayInYear: (4 - 1) * 30 + 10, year: 178, hour: 0, minute: 0, second: 0, nanosecond: 0, timeZone: appropriateTimeZone)
         let unixOriginOnFRCAsDate2 = unixOriginOnFRC2.date
-        debugPrint("• Origin:", unixOriginOnFRCAsDate2)
-        debugPrint("• FRC date:", unixOriginOnFRC2)
-        debugPrint("• FRC date as ordinary date:", df2.string(from: unixOriginOnFRCAsDate2))
+//        debugPrint("• Origin:", unixOriginOnFRCAsDate2)
+//        debugPrint("• FRC date:", unixOriginOnFRC2)
+//        debugPrint("• FRC date as ordinary date:", df2.string(from: unixOriginOnFRCAsDate2))
         let unixOriginOnFRCAsDate2AsString = df.string(from: unixOriginOnFRCAsDate2)
-        debugPrint("• FRC date string for comparison:", unixOriginOnFRCAsDate2AsString)
+//        debugPrint("• FRC date string for comparison:", unixOriginOnFRCAsDate2AsString)
         XCTAssertEqual(unixOriginOnFRCAsDate2AsString, unixOriginAsString)
 
-        // Testing 2022-08-08 CE, today when the test was written
+        // Testing 2022-08-08 CE, the day when the test was written
         let todayAsString = "2022-08-08"
-//        let today = df.date(from: todayAsString)!
         let today = gregorianDate(era: 1, year: 2022, month: 8, day: 8, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
         let todayOnFRC = FrenchRepublicanDate(date: today)
         let todayOnFRCAsDate = todayOnFRC.date

--- a/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
+++ b/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
@@ -86,17 +86,26 @@ class FrenchRepublicanCalendarTests: XCTestCase {
  
         debugPrint(#file, #function, appropriateTimeZone.identifier, appropriateTimeZone.secondsFromGMT() / (60 * 60))
        
-        // Testing 01/01/1 FRC
-        for variant in FrenchRepublicanDateOptions.Variant.allCases {
-            let rawFRCDateOrigin: Date = FrenchRepublicanDate.origin
-            let frcDateOrigin: Date = rawFRCDateOrigin.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin)))
-            let frcDate: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin, options: .init(romanYear: false, variant: variant), timeZone: appropriateTimeZone)
-            debugPrint("• Variant:", variant)
-            debugPrint("• Origin:", df2.string(from: frcDateOrigin))
+        let expectedOriginString = "01/01/1"
+        // Testing 01/01/1 FRC:  Original
+//            let rawFRCDateOrigin: Date = FrenchRepublicanDate.origin
+//            let frcDateOrigin: Date = rawFRCDateOrigin.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin)))
+        let frcDateOrigin: Date = gregorianDate(era: 1, year: 1792, month: 9, day: 22, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
+            let frcDate: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin, options: .init(romanYear: false, variant: .original), timeZone: appropriateTimeZone)
+            debugPrint("• Variant:  Original")
+            debugPrint("• Origin:", frcDateOrigin)
             debugPrint("• FRC date:", frcDate)
-            let expectedOriginString = "01/01/1"
             XCTAssertEqual(frcDate.toShortenedString(), expectedOriginString)
-        }
+        
+        // Testing 01/01/1 FRC:  Romme
+//        let rawFRCDateOrigin2: Date = FrenchRepublicanDate.origin
+//        let frcDateOrigin2: Date = rawFRCDateOrigin2.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin2)))
+        let frcDateOrigin2: Date = gregorianDate(era: 1, year: 1792, month: 9, day: 22, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
+        let frcDate2: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin2, options: .init(romanYear: false, variant: .romme), timeZone: appropriateTimeZone)
+        debugPrint("• Variant:  Romme")
+        debugPrint("• Origin:", frcDateOrigin2)
+        debugPrint("• FRC date:", frcDate2)
+        XCTAssertEqual(frcDate2.toShortenedString(), expectedOriginString)
         
         // Testing 18/02/8 FRC
         let expected9November1799String = "1799-11-09"
@@ -127,7 +136,7 @@ class FrenchRepublicanCalendarTests: XCTestCase {
         
         let unixOriginOnFRC2 = FrenchRepublicanDate(dayInYear: (4 - 1) * 30 + 10, year: 178, hour: 0, minute: 0, second: 0, nanosecond: 0, timeZone: appropriateTimeZone)
         let unixOriginOnFRCAsDate2 = unixOriginOnFRC2.date
-        debugPrint("• Origin:", df2.string(from: unixOriginOnFRCAsDate2))
+        debugPrint("• Origin:", unixOriginOnFRCAsDate2)
         debugPrint("• FRC date:", unixOriginOnFRC2)
         debugPrint("• FRC date as ordinary date:", df2.string(from: unixOriginOnFRCAsDate2))
         let unixOriginOnFRCAsDate2AsString = df.string(from: unixOriginOnFRCAsDate2)
@@ -178,7 +187,7 @@ class FrenchRepublicanCalendarTests: XCTestCase {
         testHistoricalDatesFor(Tasmania)
 
         let McMurdo = TimeZone(identifier: "Antarctica/McMurdo")! // +12
-        testHistoricalDatesFor(McMurdo)        
+        testHistoricalDatesFor(McMurdo)
     }
     
     func testCurrentDate() throws {

--- a/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
+++ b/Tests/FrenchRepublicanCalendarCoreTests/FrenchRepublicanCalendarTests.swift
@@ -52,15 +52,133 @@ class FrenchRepublicanCalendarTests: XCTestCase {
         }
     }
     
+    fileprivate func gregorianDate(era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, timeZone: TimeZone) -> Date {
+        var dateComponents = DateComponents()
+        dateComponents.era      = era
+        dateComponents.year     = year
+        dateComponents.month    = month
+        dateComponents.day      = day
+        dateComponents.timeZone = timeZone
+        dateComponents.hour     = hour
+        dateComponents.minute   = minute
+        dateComponents.second   = second
+
+        // Create date from components
+        let userCalendar = Calendar(identifier: .gregorian) // since the components above (like year 1980) are for Gregorian
+        return userCalendar.date(from: dateComponents)!
+    }
+    
+    @available(iOS 10.0, *)
+    fileprivate func testHistoricalDatesFor(_ timeZone: TimeZone?) {
+        debugPrint("################################################################################")
+        let appropriateTimeZone: TimeZone = timeZone ?? TimeZone.current
+
+//        let df = ISO8601DateFormatter()
+//        df.formatOptions = .withFullDate
+//        df.timeZone = timeZone
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.timeZone = appropriateTimeZone
+        
+        let df2 = DateFormatter()
+        df2.dateFormat = "yyyy-MM-dd\'T\'HH:mm:ss\'.000\'z"
+        df2.timeZone = appropriateTimeZone
+ 
+        debugPrint(#file, #function, appropriateTimeZone.identifier, appropriateTimeZone.secondsFromGMT() / (60 * 60))
+       
+        // Testing 01/01/1 FRC
+        for variant in FrenchRepublicanDateOptions.Variant.allCases {
+            let rawFRCDateOrigin: Date = FrenchRepublicanDate.origin
+            let frcDateOrigin: Date = rawFRCDateOrigin.addingTimeInterval(TimeInterval((appropriateTimeZone).secondsFromGMT(for: rawFRCDateOrigin)))
+            let frcDate: FrenchRepublicanDate = FrenchRepublicanDate(date: frcDateOrigin, options: .init(romanYear: false, variant: variant), timeZone: appropriateTimeZone)
+            debugPrint("• Variant:", variant)
+            debugPrint("• Origin:", df2.string(from: frcDateOrigin))
+            debugPrint("• FRC date:", frcDate)
+            let expectedOriginString = "01/01/1"
+            XCTAssertEqual(frcDate.toShortenedString(), expectedOriginString)
+        }
+        
+        // Testing 18/02/8 FRC
+        let expected9November1799String = "1799-11-09"
+//        let dateFor9November1799: Date = df.date(from: expected9November1799String)!
+        let dateFor9November1799: Date = gregorianDate(era: 1, year: 1799, month: 11, day: 9, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
+        let frcFor9November1799: FrenchRepublicanDate = FrenchRepublicanDate(date: dateFor9November1799, timeZone: appropriateTimeZone)
+        let frcFor9November1799String: String = frcFor9November1799.toShortenedString()
+        debugPrint("• 9 November 1799:", dateFor9November1799)
+        debugPrint("• FRC date for 9 November 1799:", frcFor9November1799)
+        debugPrint("• String for FRC date for 9 November 1799:", frcFor9November1799String)
+        let stringFor18Brumaire8 = "18/02/8"
+        XCTAssertEqual(frcFor9November1799String, stringFor18Brumaire8)
+        let frcFor18Brumaire8: FrenchRepublicanDate = FrenchRepublicanDate(dayInYear: 48, year: 8, hour: 0, minute: 0, second: 0, nanosecond: 0, timeZone: appropriateTimeZone)
+        let dateForFRCFor18Brumaire8: Date = frcFor18Brumaire8.date
+        let stringForFRCFor18Brumaire8: String = df.string(from: dateForFRCFor18Brumaire8)
+        debugPrint("• FRC date for 18 Brumaire 8:", frcFor18Brumaire8)
+        debugPrint("• Date for 18 Brumaire 8:", dateForFRCFor18Brumaire8)
+        debugPrint("• String for date for 18 Brumaire 8:", stringForFRCFor18Brumaire8)
+        XCTAssertEqual(stringForFRCFor18Brumaire8, expected9November1799String)
+        
+        // Testing 1970-01-01 CE
+        let unixOriginAsString = "1970-01-01"
+//        let unixOrigin = df.date(from: unixOriginAsString)!
+        let unixOrigin = gregorianDate(era: 1, year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
+        let unixOriginOnFRC = FrenchRepublicanDate(date: unixOrigin, timeZone: appropriateTimeZone)
+        let unixOriginOnFRCAsDate = unixOriginOnFRC.date
+        XCTAssertEqual(df.string(from: unixOriginOnFRCAsDate), unixOriginAsString)
+        
+        let unixOriginOnFRC2 = FrenchRepublicanDate(dayInYear: (4 - 1) * 30 + 10, year: 178, hour: 0, minute: 0, second: 0, nanosecond: 0, timeZone: appropriateTimeZone)
+        let unixOriginOnFRCAsDate2 = unixOriginOnFRC2.date
+        debugPrint("• Origin:", df2.string(from: unixOriginOnFRCAsDate2))
+        debugPrint("• FRC date:", unixOriginOnFRC2)
+        debugPrint("• FRC date as ordinary date:", df2.string(from: unixOriginOnFRCAsDate2))
+        let unixOriginOnFRCAsDate2AsString = df.string(from: unixOriginOnFRCAsDate2)
+        debugPrint("• FRC date string for comparison:", unixOriginOnFRCAsDate2AsString)
+        XCTAssertEqual(unixOriginOnFRCAsDate2AsString, unixOriginAsString)
+
+        // Testing 2022-08-08 CE, today when the test was written
+        let todayAsString = "2022-08-08"
+//        let today = df.date(from: todayAsString)!
+        let today = gregorianDate(era: 1, year: 2022, month: 8, day: 8, hour: 0, minute: 0, second: 0, timeZone: appropriateTimeZone)
+        let todayOnFRC = FrenchRepublicanDate(date: today)
+        let todayOnFRCAsDate = todayOnFRC.date
+        XCTAssertEqual(df.string(from: todayOnFRCAsDate), todayAsString)
+    }
+    
     @available(iOS 10.0, *)
     func testHistoricalDates() {
-        let df = ISO8601DateFormatter()
-        df.formatOptions = .withFullDate
-        for variant in FrenchRepublicanDateOptions.Variant.allCases {
-            XCTAssertEqual(FrenchRepublicanDate(date: FrenchRepublicanDate.origin, options: .init(romanYear: false, variant: variant)).toShortenedString(), "01/01/1")
-        }
-        XCTAssertEqual(FrenchRepublicanDate(date: df.date(from: "1799-11-09")!).toShortenedString(), "18/02/8")
-        XCTAssertEqual(df.string(from: FrenchRepublicanDate(dayInYear: 49, year: 8).date), "1799-11-09")
+        testHistoricalDatesFor(nil)
+    }
+    
+    @available(iOS 10.0, *)
+    func testHistoricalDatesInTimeZones() {
+        let Honolulu = TimeZone(identifier: "Pacific/Honolulu")! // -10
+        testHistoricalDatesFor(Honolulu)
+
+        let Anchorage = TimeZone(identifier: "America/Anchorage")! // -9
+        testHistoricalDatesFor(Anchorage)
+
+        let SaoPaulo = TimeZone(identifier: "America/Sao_Paulo")! // -3
+        testHistoricalDatesFor(SaoPaulo)
+
+        let Dublin = TimeZone(identifier: "Europe/Dublin")! // +0
+        testHistoricalDatesFor(Dublin)
+
+        let Paris = TimeZone(identifier: "Europe/Paris")! // +1
+        testHistoricalDatesFor(Paris)
+
+        let Bucharest = TimeZone(identifier: "Europe/Bucharest")! // +2
+        testHistoricalDatesFor(Bucharest)
+
+        let AddisAbaba = TimeZone(identifier: "Africa/Addis_Ababa")! // +3
+        testHistoricalDatesFor(AddisAbaba)
+
+        let Brunei = TimeZone(identifier: "Asia/Brunei")! // +8
+        testHistoricalDatesFor(Brunei)
+
+        let Tasmania = TimeZone(identifier: "Australia/Tasmania")! // +10
+        testHistoricalDatesFor(Tasmania)
+
+        let McMurdo = TimeZone(identifier: "Antarctica/McMurdo")! // +12
+        testHistoricalDatesFor(McMurdo)        
     }
     
     func testCurrentDate() throws {


### PR DESCRIPTION
In incorporating FrenchRepublicanCalendarCore into one of my projects, I realized that it did not support time zones, so I fixed it.  I also made it possible to treat Sansculottides as a 13th month in formatted dates, and I was very careful to make sure that the original API was still valid.  Enjoy.